### PR TITLE
Set renderingWebView baseURL to the app Bundle Path

### DIFF
--- a/PdfReportKit/PRKRenderHtmlOperation.m
+++ b/PdfReportKit/PRKRenderHtmlOperation.m
@@ -38,7 +38,10 @@
     executing = YES;
     [self didChangeValueForKey:@"isExecuting"];
     
-    [renderingWebView loadHTMLString:htmlSource baseURL:[NSURL URLWithString:@"http://localhost"]];
+    NSString *path = [[NSBundle mainBundle] bundlePath];
+    NSURL *baseURL = [NSURL fileURLWithPath:path];
+    
+    [renderingWebView loadHTMLString:htmlSource baseURL:baseURL];
 }
 
 - (BOOL)isConcurrent


### PR DESCRIPTION
I made this slight change so that I can now easily use local images in my PDF template by simply using

<img src="mylocalImageFile.png">
